### PR TITLE
Revert repo back to dependabot.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: nuget
-  directory: "/Solutions"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Initial testing complete, the migration to GitHub dependabot will start with Menes